### PR TITLE
Removed: polyfill

### DIFF
--- a/style-guide/_templates/scripts.html
+++ b/style-guide/_templates/scripts.html
@@ -120,6 +120,3 @@
     }
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
-<script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
-</script>


### PR DESCRIPTION
@ssalinas24 

URL: https://developer.rackspace.com/docs/style-guide/ lands to one wiki page: https://one.rackspace.com/pages/viewpage.action?spaceKey=rssplatform&title=Customer+Documentation+Style+Guide

If everything looks good, could you please confirm the changes and merge.